### PR TITLE
Fix the parsing of truncated messages

### DIFF
--- a/src/mavlink-v2/__tests__/mavlink-parser-v2.test.ts
+++ b/src/mavlink-v2/__tests__/mavlink-parser-v2.test.ts
@@ -24,6 +24,8 @@
 import {MAVLinkModule} from "../../mavlink-module";
 import {ParserState} from "../../parser-state.enum";
 import {messageRegistry} from "../../../assets/message-registry";
+import {MAVLinkMessage} from "../../mavlink-message";
+import {MessageInterval} from "../../../assets/messages/message-interval";
 
 let mavlinkModule: MAVLinkModule;
 
@@ -70,4 +72,20 @@ test('MessageStartNotFoundEmptyBuffer', () => {
     mavlinkModule.parse(Buffer.from([0x02, 0x11, 0xFF]));
     // @ts-ignore
     expect(mavlinkModule.parser.buffer.length).toBe(0);
+});
+
+test('MessageTruncated', () => {
+    const testMessage = new MessageInterval(255, 0);
+    testMessage.interval_us = 1;
+    const message_id = 2;
+    testMessage.message_id = message_id;
+    const testMessages: MAVLinkMessage[] = Array<MAVLinkMessage>();
+    testMessages.push(testMessage);
+
+    const buffer = mavlinkModule.pack(testMessages);
+    return mavlinkModule.parse(buffer).then(message => {
+        expect.assertions(1);
+        // @ts-ignore
+        expect(message[0].message_id).toBe(message_id);
+    });
 });

--- a/src/mavlink-v2/mavlink-parser-v2.ts
+++ b/src/mavlink-v2/mavlink-parser-v2.ts
@@ -78,9 +78,17 @@ export class MAVLinkParserV2 extends MAVLinkParserBase {
                 if (payload.length > start + field_length) {
                     message[field_name] = this.read(payload, start, field_type);
                     start += field_length;
-                } else { // payload truncation
-                    message[field_name] = 0;
-                    start += field_length;
+                } else {
+                    if (payload.readUInt8(start) === 0) { // payload truncation (last field was zero)
+                        message[field_name] = 0;
+                        start += field_length;
+                    } else { // append the truncated zero bytes so that we can parse the last field
+                        const truncated: Buffer = payload.slice(start);
+                        const filler: Buffer = Buffer.alloc(field_length - truncated.length);
+                        const buf = Buffer.concat([truncated, filler]);
+                        message[field_name] = this.read(buf, 0, field_type);
+                        start += field_length;
+                    }
                 }
             }
 


### PR DESCRIPTION
Hi,

this PR fixes the parsing of truncated messages.
I am using a modified [MISSION_REQUEST_INT](https://mavlink.io/en/messages/common.html#MISSION_REQUEST_INT) with this definition:
```xml
<message id="51" name="MISSION_REQUEST_INT">
  <description>Request the information of the mission item with the sequence number seq.</description>
  <field type="uint16_t" name="seq">Sequence</field>
</message>
```
A serialized message with `seq=2` looks like this:
`0xfd, 0x1, 0x0, 0x0, 0x0, 0xff, 0x0, 0x33, 0x0, 0x0, 0x2, 0x3b, 0xc0`

This was getting parsed to `seq=0`, because every truncated field was set to zero.
Now it will only return zero if the first byte is zero, otherwise the truncated bytes will get added according to the `field_length` and then the correct value is parsed.

Thanks for the awesome library, it is used in an electron mission planer gui for robotic sailboats.

Greetings from the Heilbronn University :)