### PR TITLE
Fix non trailing zero message

### DIFF
--- a/src/mavlink-v2/__tests__/mavlink-parser-v2.test.ts
+++ b/src/mavlink-v2/__tests__/mavlink-parser-v2.test.ts
@@ -89,3 +89,10 @@ test('MessageTruncated', () => {
         expect(message[0].message_id).toBe(message_id);
     });
 });
+
+test('MessageTruncatedNonTrailingZero', () => {
+    const buffer = Buffer.from([0xfd, 0x5, 0x0, 0x0, 0x0, 0xff, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x27, 0xdb])
+
+    expect.assertions(1);
+    return expect(mavlinkModule.parse(buffer)).resolves.toBeDefined();
+});

--- a/src/mavlink-v2/mavlink-parser-v2.ts
+++ b/src/mavlink-v2/mavlink-parser-v2.ts
@@ -79,7 +79,7 @@ export class MAVLinkParserV2 extends MAVLinkParserBase {
                     message[field_name] = this.read(payload, start, field_type);
                     start += field_length;
                 } else {
-                    if (payload.readUInt8(start) === 0) { // payload truncation (last field was zero)
+                    if (start >= payload.length || payload.readUInt8(start) === 0) { // payload truncation (last field was zero)
                         message[field_name] = 0;
                         start += field_length;
                     } else { // append the truncated zero bytes so that we can parse the last field


### PR DESCRIPTION
This PR fixes a bug if the last field in the message is zero.
The field will get truncated and `payload.readUInt8(start)` will throw a range error.
This check `start >= payload.length` fixes the bug.