### PR TITLE
Length of mavlink message extension fields bug

### DIFF
--- a/src/mavlink-message.ts
+++ b/src/mavlink-message.ts
@@ -147,7 +147,7 @@ export abstract class MAVLinkMessage implements IMAVLinkMessage, IIndexable {
 
     get _extension_length(): number {
         let length = 0;
-        for (let field of this._message_fields.filter(field => !field[2])) {
+        for (let field of this._message_fields.filter(field => field[2])) {
             length += this.sizeof(field[1]);
         }
         return length;


### PR DESCRIPTION
_extension_length was not being calculated correctly, since _message_fields[2] is a boolean that, if true, indicates this field is an extension field, the getter for _extension_length was calculating the length based if it's false (like the _payload_length)